### PR TITLE
Potential fix for code scanning alert no. 8: Incomplete string escaping or encoding

### DIFF
--- a/server/src/main/resources/static/old-console/js/jquery-ui-1.9.2.js
+++ b/server/src/main/resources/static/old-console/js/jquery-ui-1.9.2.js
@@ -13457,7 +13457,7 @@ $.widget( "ui.tabs", {
 	},
 
 	_sanitizeSelector: function( hash ) {
-		return hash ? hash.replace( /[!"$%&'()*+,.\/:;<=>?@\[\]\^`{|}~]/g, "\\$&" ) : "";
+		return hash ? hash.replace(/\\/g, "\\\\").replace( /[!"$%&'()*+,.\/:;<=>?@\[\]\^`{|}~]/g, "\\$&" ) : "";
 	},
 
 	refresh: function() {


### PR DESCRIPTION
Potential fix for [https://github.com/superbstreak/druid/security/code-scanning/8](https://github.com/superbstreak/druid/security/code-scanning/8)

To fix the problem, we need to ensure that backslashes are properly escaped in the input string. This can be done by modifying the regular expression used in the `replace` method to include backslashes. Specifically, we should add a rule to replace backslashes with double backslashes before applying the existing replacement rules. This ensures that all occurrences of backslashes are properly escaped.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
